### PR TITLE
Upgrade to mongo driver 4.x and java 8 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.jongo</groupId>
     <artifactId>jongo</artifactId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Jongo</name>
     <description>Query in Java as in Mongo shell</description>
@@ -72,7 +72,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <mongo-java-driver.version>[3.5.0,3.10.1]</mongo-java-driver.version>
+        <mongo-driver-legacy.version>[4.0.0,4.1.1]</mongo-driver-legacy.version>
         <jackson.version>2.10.3</jackson.version>
         <bson4jackson.version>2.9.2</bson4jackson.version>
     </properties>
@@ -80,8 +80,8 @@
     <dependencies>
         <dependency>
             <groupId>org.mongodb</groupId>
-            <artifactId>mongo-java-driver</artifactId>
-            <version>${mongo-java-driver.version}</version>
+            <artifactId>mongodb-driver-legacy</artifactId>
+            <version>${mongo-driver-legacy.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -147,7 +147,7 @@
         <dependency>
             <groupId>de.flapdoodle.embed</groupId>
             <artifactId>de.flapdoodle.embed.mongo</artifactId>
-            <version>2.2.0</version>
+            <version>3.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -164,8 +164,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <mongo-driver-legacy.version>[4.0.0,4.1.1]</mongo-driver-legacy.version>
         <jackson.version>2.10.3</jackson.version>
-        <bson4jackson.version>2.9.2</bson4jackson.version>
+        <bson4jackson.version>2.12.0</bson4jackson.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/org/jongo/Aggregate.java
+++ b/src/main/java/org/jongo/Aggregate.java
@@ -70,7 +70,7 @@ public class Aggregate {
         if (options != null) {
             results = collection.aggregate(pipeline, options);
         } else {
-            results = collection.aggregate(pipeline).results().iterator();
+            results = collection.aggregate(pipeline, AggregationOptions.builder().build());
         }
         return new ResultsIterator<T>(results, resultHandler);
     }

--- a/src/main/java/org/jongo/JongoNative.java
+++ b/src/main/java/org/jongo/JongoNative.java
@@ -20,6 +20,7 @@ package org.jongo;
 import com.mongodb.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
+import org.bson.BsonDocument;
 import org.bson.Document;
 import org.bson.codecs.BsonValueCodecProvider;
 import org.bson.codecs.configuration.CodecRegistries;
@@ -54,9 +55,9 @@ public class JongoNative {
         return wrapCollection(collection);
     }
 
-    public Bson query(String query, Object... parameters) {
+    public BsonDocument query(String query, Object... parameters) {
         Query q = mapper.getQueryFactory().createQuery(query, parameters);
-        return q.toBson();
+        return q.toBsonDocument();
     }
 
     public Bson id(Object id) {

--- a/src/main/java/org/jongo/MongoCollection.java
+++ b/src/main/java/org/jongo/MongoCollection.java
@@ -103,7 +103,7 @@ public class MongoCollection {
     }
 
     public long count() {
-        return collection.getCount(readPreference);
+        return collection.getCount();
     }
 
     public long count(String query) {
@@ -112,7 +112,7 @@ public class MongoCollection {
 
     public long count(String query, Object... parameters) {
         DBObject dbQuery = createQuery(query, parameters).toDBObject();
-        return collection.getCount(dbQuery, null, readPreference);
+        return collection.getCount(dbQuery, null);
     }
 
     public Update update(String query) {

--- a/src/main/java/org/jongo/MongoCollection.java
+++ b/src/main/java/org/jongo/MongoCollection.java
@@ -112,7 +112,7 @@ public class MongoCollection {
 
     public long count(String query, Object... parameters) {
         DBObject dbQuery = createQuery(query, parameters).toDBObject();
-        return collection.getCount(dbQuery, null);
+        return collection.getCount(dbQuery);
     }
 
     public Update update(String query) {

--- a/src/main/java/org/jongo/marshall/jackson/bson4jackson/BsonDeserializers.java
+++ b/src/main/java/org/jongo/marshall/jackson/bson4jackson/BsonDeserializers.java
@@ -29,7 +29,6 @@ import com.fasterxml.jackson.databind.node.TextNode;
 import com.fasterxml.jackson.databind.node.ValueNode;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
-import com.mongodb.util.JSON;
 import org.bson.conversions.Bson;
 import org.bson.types.*;
 
@@ -112,7 +111,7 @@ class BsonDeserializers extends SimpleDeserializers {
         @Override
         public T deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException, JsonProcessingException {
             String asString = jp.readValueAsTree().toString();
-            return (T) JSON.parse(asString);
+            return (T) BasicDBObject.parse(asString);
         }
     }
 

--- a/src/main/java/org/jongo/marshall/jackson/bson4jackson/MongoBsonParser.java
+++ b/src/main/java/org/jongo/marshall/jackson/bson4jackson/MongoBsonParser.java
@@ -53,7 +53,7 @@ class MongoBsonParser extends BsonParser {
     }
 
     private org.bson.types.ObjectId convertToNativeObjectId(ObjectId id) {
-        return org.bson.types.ObjectId.createFromLegacyFormat(id.getTime(), id.getMachine(), id.getInc());
+        return new org.bson.types.ObjectId(id.getTime(), id.getInc());
     }
 
     private org.bson.types.Decimal128 convertToNativeDecimal128(Decimal128 decimal) {

--- a/src/main/java/org/jongo/marshall/jackson/bson4jackson/MongoBsonParser.java
+++ b/src/main/java/org/jongo/marshall/jackson/bson4jackson/MongoBsonParser.java
@@ -30,6 +30,8 @@ import java.nio.ByteBuffer;
 
 class MongoBsonParser extends BsonParser {
 
+    private static final int OBJECT_ID_LENGTH = 12;
+
     public MongoBsonParser(IOContext ctxt, int jsonFeatures, int bsonFeatures, InputStream in) {
         super(ctxt, jsonFeatures, bsonFeatures, in);
     }
@@ -54,21 +56,27 @@ class MongoBsonParser extends BsonParser {
     }
 
     private org.bson.types.ObjectId convertToNativeObjectId(ObjectId id) {
-        // Evil hack because of bson4jackson library which is not compatible with the new ObjectId spec
-        ByteBuffer buffer = ByteBuffer.allocate(12);
-        buffer.put(int3(id.getTime()));
-        buffer.put(int2(id.getTime()));
-        buffer.put(int1(id.getTime()));
-        buffer.put(int0(id.getTime()));
-        buffer.put(int3(id.getMachine()));
-        buffer.put(int2(id.getMachine()));
-        buffer.put(int1(id.getMachine()));
-        buffer.put(int0(id.getMachine()));
-        buffer.put(int3(id.getInc()));
-        buffer.put(int2(id.getInc()));
-        buffer.put(int1(id.getInc()));
-        buffer.put(int0(id.getInc()));
-        return new org.bson.types.ObjectId(buffer.array());
+        return new org.bson.types.ObjectId(createFromLegacyFormat(id.getTime(), id.getMachine(), id.getInc()));
+    }
+
+    private byte[] createFromLegacyFormat(int time, int machine, int inc) {
+        // Reimplementing createFromLegacyFormat because bson4jackson library is not compatible with the new ObjectId spec
+        // see issue https://github.com/michel-kraemer/bson4jackson/issues/94
+        // Former implementation https://github.com/mongodb/mongo-java-driver/blob/3.12.x/bson/src/main/org/bson/types/ObjectId.java#L248
+        ByteBuffer buffer = ByteBuffer.allocate(OBJECT_ID_LENGTH);
+        buffer.put(int3(time));
+        buffer.put(int2(time));
+        buffer.put(int1(time));
+        buffer.put(int0(time));
+        buffer.put(int3(machine));
+        buffer.put(int2(machine));
+        buffer.put(int1(machine));
+        buffer.put(int0(machine));
+        buffer.put(int3(inc));
+        buffer.put(int2(inc));
+        buffer.put(int1(inc));
+        buffer.put(int0(inc));
+        return buffer.array();
     }
 
     private org.bson.types.Decimal128 convertToNativeDecimal128(Decimal128 decimal) {

--- a/src/main/java/org/jongo/marshall/jackson/configuration/AbstractMappingBuilder.java
+++ b/src/main/java/org/jongo/marshall/jackson/configuration/AbstractMappingBuilder.java
@@ -16,6 +16,7 @@
 
 package org.jongo.marshall.jackson.configuration;
 
+import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.introspect.VisibilityChecker;
 import com.fasterxml.jackson.databind.module.SimpleModule;

--- a/src/main/java/org/jongo/query/BsonQueryFactory.java
+++ b/src/main/java/org/jongo/query/BsonQueryFactory.java
@@ -26,7 +26,13 @@ import org.jongo.bson.BsonDocument;
 import org.jongo.marshall.Marshaller;
 import org.jongo.marshall.MarshallingException;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import static org.jongo.query.BsonSpecialChar.itIsABsonSpecialChar;
+import static org.jongo.query.BsonSpecialChar.specialChar;
 
 public class BsonQueryFactory implements QueryFactory {
 
@@ -43,6 +49,7 @@ public class BsonQueryFactory implements QueryFactory {
     private static final String MARSHALL_OPERATOR = "8a6e4178-8fba-4d22-af43-840512e3a999-marshall";
 
     private final String token;
+    private final boolean singleCharToken;
     private final Marshaller marshaller;
 
     private static class BsonQuery implements Query {
@@ -66,6 +73,7 @@ public class BsonQueryFactory implements QueryFactory {
     }
 
     public BsonQueryFactory(Marshaller marshaller, String token) {
+        this.singleCharToken = token.length() == 1;
         this.token = token;
         this.marshaller = marshaller;
     }
@@ -105,89 +113,41 @@ public class BsonQueryFactory implements QueryFactory {
     }
 
     private String addRequiredQuotesAndParameters(String query, Object[] parameters) {
-        StringBuilder sb = new StringBuilder(query.length());
+        StringBuilder result = new StringBuilder(query.length());
 
         int position = 0;
         int paramIndex = 0;
-        Stack<Context> stack = new Stack<>(Context.NONE);
-        Context ctx;
-        String token = "";
+        Stack<Context> ctxStack = new Stack<>(Context.NONE);
+        StringBuilder currentToken = new StringBuilder();
         String previousToken = "";
         char currentStringStartingQuote = ' ';
-        for (char c : query.toCharArray()) {
-            ctx = stack.peek();
-            if (ctx == Context.STRING) {
-                token += c;
-                if (c == currentStringStartingQuote) {
-                    stack.pop();
+
+        for (char nextChar : query.toCharArray()) {
+            if (ctxStack.peek() == Context.STRING) {
+                currentToken.append(nextChar);
+                if (nextChar == currentStringStartingQuote) {
+                    ctxStack.pop();
                 }
-            } else if (c == '\'' || c == '"') {
-                stack.push(Context.STRING);
-                currentStringStartingQuote = c;
-                token += c;
-            } else if ((token + c).lastIndexOf(this.token) == token.length() - this.token.length() + 1) {
+            } else if (isAQuote(nextChar)) {
+                ctxStack.push(Context.STRING);
+                currentStringStartingQuote = nextChar;
+                currentToken.append(nextChar);
+            } else if (currentTokenWithNextCharIsToken(currentToken, nextChar)) {
                 if (paramIndex >= parameters.length) {
                     throw new IllegalArgumentException("Not enough parameters passed to query: " + query);
                 }
                 if ("$oid".equals(previousToken) ||
                         !isValueToken(query, position)) {
-                    token = "\"" + token.trim() + parameters[paramIndex] + "\"";
+                    currentToken = trimAppendParamAndQuote(currentToken, parameters[paramIndex]);
                 } else {
-                    sb.append("{\"")
-                            .append(MARSHALL_OPERATOR)
-                            .append("\":")
-                            .append(paramIndex).append("}");
+                    appendParamPlaceholder(result, paramIndex);
+                    currentToken.setLength(0);
                 }
                 paramIndex++;
-            } else if (c == '{') {
-                stack.push(Context.OBJECT);
-                sb.append("{");
-            } else if (c == '[') {
-                stack.push(Context.ARRAY);
-                sb.append("[");
-            } else if (c == '}') {
-                ctx = stack.pop();
-                if (ctx != Context.OBJECT) {
-                    throw new IllegalArgumentException("Invalid token at position: " + position);
-                }
-
-                if (!token.isEmpty()) {
-                    sb.append(token);
-                }
-
-                previousToken = token;
-                token = "";
-                sb.append("}");
-            } else if (c == ']') {
-                ctx = stack.pop();
-                if (ctx != Context.ARRAY) {
-                    throw new IllegalArgumentException("Invalid token at position: " + position);
-                }
-
-                if (!token.isEmpty()) {
-                    sb.append(token);
-                }
-
-                previousToken = token;
-                token = "";
-                sb.append("]");
-            } else if (c == ':') {
-                String key = token.trim();
-                if (key.isEmpty() || key.equals("\"\"") || key.equals("''")) {
-                    throw new IllegalArgumentException("Invalid token at position: " + position);
-                }
-
-                sb.append(isQuoted(key) ? key : quote(key));
-                sb.append(":");
-                previousToken = token;
-                token = "";
-            } else if (c == ',') {
-                sb.append(token);
-                sb.append(",");
-                previousToken = token;
-                token = "";
+            } else if (itIsABsonSpecialChar(nextChar)) {
+                previousToken = specialChar(nextChar).applySpecificBehaviour(result, currentToken, ctxStack, position);
             } else {
-                token += c;
+                currentToken.append(nextChar);
             }
 
             position++;
@@ -197,62 +157,35 @@ public class BsonQueryFactory implements QueryFactory {
             throw new IllegalArgumentException("Too many parameters passed to query: " + query);
         }
 
-        return sb.toString().trim();
+        return result.toString().trim();
     }
 
-    public enum Context {
-        NONE,
-        OBJECT,
-        ARRAY,
-        STRING;
+    private boolean currentTokenWithNextCharIsToken(StringBuilder currentToken, char nextChar) {
+        if (this.singleCharToken) {
+            return this.token.charAt(0) == nextChar;
+        }
+        return (currentToken.toString().trim() + nextChar).lastIndexOf(this.token) >= 0;
     }
 
-    private static boolean isQuoted(String token) {
-        char start = token.charAt(0);
-        char end = token.charAt(token.length() - 1);
-        if (start == '\'' && end == '\'') {
-            return true;
-        }
-
-        if (start == '"' && end == '"') {
-            return true;
-        }
-
-        return false;
+    private void appendParamPlaceholder(StringBuilder result, int paramIndex) {
+        result.append('{')
+                .append('"')
+                .append(MARSHALL_OPERATOR)
+                .append('"')
+                .append(':')
+                .append(paramIndex)
+                .append('}');
     }
 
-    private static String quote(String token) {
-        return "\"" + token + "\"";
+    private StringBuilder trimAppendParamAndQuote(StringBuilder currentToken, Object parameter) {
+        return new StringBuilder().append('"')
+                .append(currentToken.toString().trim())
+                .append(parameter)
+                .append('"');
     }
 
-    private static class Stack<T> {
-        private final LinkedList<T> stack;
-        private final T noValue;
-
-        private Stack(T noValue) {
-            this.stack = new LinkedList<>();
-            this.noValue = noValue;
-        }
-
-        public T peek() {
-            if (stack.isEmpty()) {
-                return noValue;
-            }
-
-            return stack.peekLast();
-        }
-
-        public T pop() {
-            if (stack.isEmpty()) {
-                return noValue;
-            }
-
-            return this.stack.removeLast();
-        }
-
-        public void push(T value) {
-            this.stack.addLast(value);
-        }
+    private boolean isAQuote(char c) {
+        return c == '\'' || c == '"';
     }
 
     private Object replaceParams(DBObject dbo, Object[] params) {

--- a/src/main/java/org/jongo/query/BsonQueryFactory.java
+++ b/src/main/java/org/jongo/query/BsonQueryFactory.java
@@ -70,56 +70,13 @@ public class BsonQueryFactory implements QueryFactory {
             parameters = new Object[]{null};
         }
 
-        String quotedQuery = addRequiredQuotes(query);
-
-        // We have two different cases:
-        //
-        // - tokens as property names "{scores.#: 1}": they must be expanded before going
-        //   through the JSON parser, and their toString() is inserted in the query
-        //
-        // - tokens as property values "{id: #}": they are resolved by the JSON parser and
-        //   therefore marshalled as DBObjects (actually LazyDBObjects).
-
-        StringBuilder sb = new StringBuilder();
-        int paramPos = 0;       // current position in the parameter list
-        int start = 0;          // start of the current string segment
-        int pos;                // position of the last token found
-        while ((pos = quotedQuery.indexOf(token, start)) != -1) {
-            if (paramPos >= parameters.length) {
-                throw new IllegalArgumentException("Not enough parameters passed to query: " + query);
-            }
-
-            // Insert chars before the token
-            sb.append(quotedQuery, start, pos);
-
-            // Check if the character preceding the token is one that separates values.
-            // Otherwise, it's a property name substitution
-            if (isValueToken(quotedQuery, pos)) {
-                // Will be resolved by the JSON parser below
-                sb.append("{\"").append(MARSHALL_OPERATOR).append("\":").append(paramPos).append("}");
-            } else {
-                // Resolve it now
-                sb.append(parameters[paramPos]);
-            }
-
-            paramPos++;
-            start = pos + token.length();
-        }
-
-        // Add remaining chars
-        sb.append(quotedQuery, start, quotedQuery.length());
-
-        if (paramPos < parameters.length) {
-            throw new IllegalArgumentException("Too many parameters passed to query: " + query);
-        }
-
+        String quotedQuery = addRequiredQuotesAndParameters(query, parameters);
 
         final Object[] params = parameters;
 
-        // Parse the query with a callback that will weave in marshalled parameters
         DBObject dbo;
         try {
-            dbo = BasicDBObject.parse(sb.toString());
+            dbo = BasicDBObject.parse(quotedQuery);
             if (params.length != 0) {
                 dbo = (DBObject) replaceParams(dbo, params);
             }
@@ -130,18 +87,41 @@ public class BsonQueryFactory implements QueryFactory {
         return new BsonQuery(dbo);
     }
 
-    private String addRequiredQuotes(String query) {
-        if (query.trim().equals("#")) {
-            return query;
-        }
-
+    private String addRequiredQuotesAndParameters(String query, Object[] parameters) {
         StringBuilder sb = new StringBuilder(query.length());
 
         int position = 0;
+        int paramIndex = 0;
         Stack<Context> stack = new Stack<>();
         String token = "";
+        String previousToken = "";
+        char currentStringStartingQuote = ' ';
         for (char c : query.toCharArray()) {
-            if (c == '{') {
+            if (stack.peek().isPresent() && stack.peek().get().equals(Context.STRING)) {
+                token += c;
+                if (c == currentStringStartingQuote) {
+                    stack.pop();
+                }
+            } else if (c == '\'' || c == '"') {
+                stack.push(Context.STRING);
+                currentStringStartingQuote = c;
+                token += c;
+            } else if ((token + c).lastIndexOf(this.token) == token.length() - this.token.length() + 1) {
+                if (paramIndex >= parameters.length) {
+                    throw new IllegalArgumentException("Not enough parameters passed to query: " + query);
+                }
+                if ("$oid".equals(previousToken) ||
+                        "$set".equals(previousToken) ||
+                        !isValueToken(query, position)) {
+                    token = "\"" + token.trim() + parameters[paramIndex] + "\"";
+                } else {
+                    sb.append("{\"")
+                            .append(MARSHALL_OPERATOR)
+                            .append("\":")
+                            .append(paramIndex).append("}");
+                }
+                paramIndex++;
+            } else if (c == '{') {
                 stack.push(Context.OBJECT);
                 sb.append("{");
             } else if (c == '[') {
@@ -157,6 +137,7 @@ public class BsonQueryFactory implements QueryFactory {
                     sb.append(token);
                 }
 
+                previousToken = token;
                 token = "";
                 sb.append("}");
             } else if (c == ']') {
@@ -169,6 +150,7 @@ public class BsonQueryFactory implements QueryFactory {
                     sb.append(token);
                 }
 
+                previousToken = token;
                 token = "";
                 sb.append("]");
             } else if (c == ':') {
@@ -179,10 +161,12 @@ public class BsonQueryFactory implements QueryFactory {
 
                 sb.append(isQuoted(key) ? key : quote(key));
                 sb.append(":");
+                previousToken = token;
                 token = "";
             } else if (c == ',') {
                 sb.append(token);
                 sb.append(",");
+                previousToken = token;
                 token = "";
             } else {
                 token += c;
@@ -191,12 +175,17 @@ public class BsonQueryFactory implements QueryFactory {
             position++;
         }
 
+        if (paramIndex < parameters.length) {
+            throw new IllegalArgumentException("Too many parameters passed to query: " + query);
+        }
+
         return sb.toString();
     }
 
     public enum Context {
         OBJECT,
         ARRAY,
+        STRING;
     }
 
     private static boolean isQuoted(String token) {
@@ -229,7 +218,7 @@ public class BsonQueryFactory implements QueryFactory {
                 return Optional.empty();
             }
 
-            return Optional.of(stack.peek());
+            return Optional.of(stack.peekLast());
         }
 
         public Optional<T> pop() {

--- a/src/main/java/org/jongo/query/BsonQueryFactory.java
+++ b/src/main/java/org/jongo/query/BsonQueryFactory.java
@@ -111,7 +111,6 @@ public class BsonQueryFactory implements QueryFactory {
                     throw new IllegalArgumentException("Not enough parameters passed to query: " + query);
                 }
                 if ("$oid".equals(previousToken) ||
-                        "$set".equals(previousToken) ||
                         !isValueToken(query, position)) {
                     token = "\"" + token.trim() + parameters[paramIndex] + "\"";
                 } else {

--- a/src/main/java/org/jongo/query/BsonQueryFactory.java
+++ b/src/main/java/org/jongo/query/BsonQueryFactory.java
@@ -76,7 +76,15 @@ public class BsonQueryFactory implements QueryFactory {
 
         DBObject dbo;
         try {
-            dbo = BasicDBObject.parse(quotedQuery);
+            if (quotedQuery.charAt(0) == '[') {
+                // little hack to handle first class arrays as BasicDBObject cannot parse them
+                // also we could do this for simple objects but it would not handle properly queries like
+                // "{'a':1}, {'b':1}" as tested in MongoCollectionTest.canCreateGeospacialIndex()
+                dbo = (DBObject) BasicDBObject.parse("{'query':" + quotedQuery + "}").get("query");
+            } else {
+                dbo = BasicDBObject.parse(quotedQuery);
+            }
+
             if (params.length != 0) {
                 dbo = (DBObject) replaceParams(dbo, params);
             }
@@ -178,7 +186,7 @@ public class BsonQueryFactory implements QueryFactory {
             throw new IllegalArgumentException("Too many parameters passed to query: " + query);
         }
 
-        return sb.toString();
+        return sb.toString().trim();
     }
 
     public enum Context {

--- a/src/main/java/org/jongo/query/BsonQueryFactory.java
+++ b/src/main/java/org/jongo/query/BsonQueryFactory.java
@@ -47,7 +47,7 @@ public class BsonQueryFactory implements QueryFactory {
             return dbo;
         }
 
-        public org.bson.conversions.Bson toBson() {
+        public org.bson.BsonDocument toBsonDocument() {
             return BsonDocumentWrapper.asBsonDocument(dbo, MongoClient.getDefaultCodecRegistry());
         }
     }

--- a/src/main/java/org/jongo/query/BsonQueryFactory.java
+++ b/src/main/java/org/jongo/query/BsonQueryFactory.java
@@ -31,7 +31,16 @@ import java.util.*;
 public class BsonQueryFactory implements QueryFactory {
 
     private static final String DEFAULT_TOKEN = "#";
-    private static final String MARSHALL_OPERATOR = UUID.randomUUID() + "marshall";
+
+    /**
+     * The marshall operator will be replacing the token during query parsing as following:
+     * {"firstname":#} -> {"firstname":{MARSHALL_OPERATOR: 0}}
+     * 0 being the index of the parameter to be inserted in place of that placeholder.
+     * Previously $marshall but upgrading to mongo driver 4 the new parser does not allow $ prefixed strings
+     * if they're not mongo operators.
+     * With a UUID prefixed string there should be no risk of collision.
+     */
+    private static final String MARSHALL_OPERATOR = "8a6e4178-8fba-4d22-af43-840512e3a999-marshall";
 
     private final String token;
     private final Marshaller marshaller;

--- a/src/main/java/org/jongo/query/BsonQueryFactory.java
+++ b/src/main/java/org/jongo/query/BsonQueryFactory.java
@@ -131,7 +131,7 @@ public class BsonQueryFactory implements QueryFactory {
     }
 
     private String addRequiredQuotes(String query) {
-        if (query.equals("#")) {
+        if (query.trim().equals("#")) {
             return query;
         }
 

--- a/src/main/java/org/jongo/query/BsonSpecialChar.java
+++ b/src/main/java/org/jongo/query/BsonSpecialChar.java
@@ -1,0 +1,129 @@
+package org.jongo.query;
+
+import java.util.HashMap;
+import java.util.Map;
+
+enum BsonSpecialChar {
+
+    LEFT_CURLY_BRACE('{') {
+        @Override
+        String applySpecificBehaviour(StringBuilder result, StringBuilder currentToken, Stack<Context> ctxStack, int position) {
+            ctxStack.push(Context.OBJECT);
+            result.append(getSpecialChar());
+            return "";
+        }
+    },
+    LEFT_SQUARE_BRACKET('[') {
+        @Override
+        String applySpecificBehaviour(StringBuilder result, StringBuilder currentToken, Stack<Context> ctxStack, int position) {
+            ctxStack.push(Context.ARRAY);
+            result.append(getSpecialChar());
+            return "";
+        }
+    },
+    RIGHT_CURLY_BRACE('}') {
+        @Override
+        String applySpecificBehaviour(StringBuilder result, StringBuilder currentToken, Stack<Context> ctxStack, int position) {
+            Context ctx = ctxStack.pop();
+            if (ctx != Context.OBJECT) {
+                throw new IllegalArgumentException("Invalid currentToken at position: " + position);
+            }
+
+            if (isNotEmpty(currentToken)) {
+                result.append(currentToken);
+            }
+
+            return appendNextCharAndPopCurrentToken(result, currentToken, getSpecialChar());
+        }
+    },
+    RIGHT_SQUARE_BRACKET(']') {
+        @Override
+        String applySpecificBehaviour(StringBuilder result, StringBuilder currentToken, Stack<Context> ctxStack, int position) {
+            Context ctx = ctxStack.pop();
+            if (ctx != Context.ARRAY) {
+                throw new IllegalArgumentException("Invalid currentToken at position: " + position);
+            }
+            if (isNotEmpty(currentToken)) {
+                result.append(currentToken);
+            }
+            return appendNextCharAndPopCurrentToken(result, currentToken, getSpecialChar());
+        }
+    },
+    COLON(':') {
+        @Override
+        String applySpecificBehaviour(StringBuilder result, StringBuilder currentToken, Stack<Context> ctxStack, int position) {
+            String key = currentToken.toString().trim();
+            if (key.isEmpty() || key.equals("\"\"") || key.equals("''")) {
+                throw new IllegalArgumentException("Invalid currentToken at position: " + position);
+            }
+            result.append(isQuoted(key) ? key : quote(key));
+            return appendNextCharAndPopCurrentToken(result, currentToken, getSpecialChar());
+        }
+    },
+    COMMA(',') {
+        @Override
+        String applySpecificBehaviour(StringBuilder result, StringBuilder currentToken, Stack<Context> ctxStack, int position) {
+            result.append(currentToken);
+            return appendNextCharAndPopCurrentToken(result, currentToken, getSpecialChar());
+        }
+    };
+
+    private static final Map<Character, BsonSpecialChar> BSON_SPECIAL_CHARS_MAP;
+
+    static {
+        BSON_SPECIAL_CHARS_MAP = new HashMap<>(BsonSpecialChar.values().length);
+        for (BsonSpecialChar c : BsonSpecialChar.values()) {
+            BSON_SPECIAL_CHARS_MAP.put(c.getSpecialChar(), c);
+        }
+    }
+
+    private final char specialChar;
+
+    BsonSpecialChar(char specialChar) {
+        this.specialChar = specialChar;
+    }
+
+    char getSpecialChar() {
+        return specialChar;
+    }
+
+    abstract String applySpecificBehaviour(StringBuilder result, StringBuilder currentToken, Stack<Context> ctxStack, int position);
+
+    private static boolean isNotEmpty(StringBuilder sb) {
+        return sb.length() > 0;
+    }
+
+    private static String appendNextCharAndPopCurrentToken(StringBuilder result, StringBuilder currentToken, char nextChar) {
+        String previousToken = currentToken.toString();
+        currentToken.setLength(0);
+        result.append(nextChar);
+        return previousToken;
+    }
+
+    private static boolean isQuoted(String token) {
+        char start = token.charAt(0);
+        char end = token.charAt(token.length() - 1);
+        if (start == '\'' && end == '\'') {
+            return true;
+        }
+
+        if (start == '"' && end == '"') {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static String quote(String token) {
+        return "\"" + token + "\"";
+    }
+
+    static boolean itIsABsonSpecialChar(char c) {
+        return BSON_SPECIAL_CHARS_MAP.containsKey(c);
+    }
+
+    static BsonSpecialChar specialChar(char c) {
+        return BSON_SPECIAL_CHARS_MAP.get(c);
+    }
+
+}

--- a/src/main/java/org/jongo/query/Context.java
+++ b/src/main/java/org/jongo/query/Context.java
@@ -1,0 +1,8 @@
+package org.jongo.query;
+
+enum Context {
+    NONE,
+    OBJECT,
+    ARRAY,
+    STRING;
+}

--- a/src/main/java/org/jongo/query/Query.java
+++ b/src/main/java/org/jongo/query/Query.java
@@ -17,11 +17,11 @@
 package org.jongo.query;
 
 import com.mongodb.DBObject;
-import org.bson.conversions.Bson;
+import org.bson.BsonDocument;
 
 public interface Query {
 
     DBObject toDBObject();
 
-    Bson toBson();
+    BsonDocument toBsonDocument();
 }

--- a/src/main/java/org/jongo/query/Stack.java
+++ b/src/main/java/org/jongo/query/Stack.java
@@ -1,0 +1,33 @@
+package org.jongo.query;
+
+import java.util.LinkedList;
+
+class Stack<T> {
+    private final LinkedList<T> stack;
+    private final T noValue;
+
+    Stack(T noValue) {
+        this.stack = new LinkedList<>();
+        this.noValue = noValue;
+    }
+
+    public T peek() {
+        if (stack.isEmpty()) {
+            return noValue;
+        }
+
+        return stack.peekLast();
+    }
+
+    public T pop() {
+        if (stack.isEmpty()) {
+            return noValue;
+        }
+
+        return this.stack.removeLast();
+    }
+
+    public void push(T value) {
+        this.stack.addLast(value);
+    }
+}

--- a/src/test/java/org/jongo/AggregateTest.java
+++ b/src/test/java/org/jongo/AggregateTest.java
@@ -36,9 +36,7 @@ import java.util.concurrent.TimeUnit;
 import static junit.framework.Assert.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 public class AggregateTest extends JongoTestBase {
 
@@ -110,7 +108,7 @@ public class AggregateTest extends JongoTestBase {
     @Test
     public void canAggregateWithOptions() {
 
-        AggregationOptions options = spy(AggregationOptions.builder().outputMode(AggregationOptions.OutputMode.CURSOR).allowDiskUse(true).build());
+        AggregationOptions options = spy(AggregationOptions.builder().allowDiskUse(true).build());
 
         articles = collection.aggregate("{$match:{}}").options(options).as(Article.class);
 
@@ -121,7 +119,6 @@ public class AggregateTest extends JongoTestBase {
         verify(options, atLeastOnce()).getAllowDiskUse();
         verify(options, atLeastOnce()).getMaxTime(any(TimeUnit.class));
         verify(options, atLeastOnce()).getBatchSize();
-        verify(options, atLeastOnce()).getOutputMode();
         assertThat(articles.isCursor()).isTrue();
     }
 

--- a/src/test/java/org/jongo/AnnotationsMisusedTest.java
+++ b/src/test/java/org/jongo/AnnotationsMisusedTest.java
@@ -49,7 +49,7 @@ public class AnnotationsMisusedTest extends JongoTestBase {
 
         ExternalFriend friend = ExternalFriend.createFriendWithoutId("Robert");
 
-        collection.withWriteConcern(WriteConcern.SAFE).save(friend);
+        collection.withWriteConcern(WriteConcern.MAJORITY).save(friend);
 
         ExternalFriend externalFriend = collection.findOne().as(ExternalFriend.class);
 
@@ -65,7 +65,7 @@ public class AnnotationsMisusedTest extends JongoTestBase {
 
         WithIntegerId custom = new WithIntegerId();
 
-        collection.withWriteConcern(WriteConcern.SAFE).save(custom);
+        collection.withWriteConcern(WriteConcern.MAJORITY).save(custom);
 
         try {
             collection.findOne().as(WithIntegerId.class);

--- a/src/test/java/org/jongo/CommandTest.java
+++ b/src/test/java/org/jongo/CommandTest.java
@@ -69,7 +69,7 @@ public class CommandTest extends JongoTestBase {
     @Test
     public void canRunACommandWithParameter() throws Exception {
 
-        collection.withWriteConcern(WriteConcern.SAFE).insert("{test:1}");
+        collection.withWriteConcern(WriteConcern.MAJORITY).insert("{test:1}");
 
         DBObject result = jongo.runCommand("{ count: #}", "friends").map(new RawResultHandler<DBObject>());
 
@@ -80,7 +80,7 @@ public class CommandTest extends JongoTestBase {
     @Test
     public void canRunAGeoNearCommand() throws Exception {
 
-        MongoCollection safeCollection = collection.withWriteConcern(WriteConcern.SAFE);
+        MongoCollection safeCollection = collection.withWriteConcern(WriteConcern.MAJORITY);
         safeCollection.insert("{loc:{lat:48.690833,lng:9.140556}, name:'Paris'}");
         safeCollection.ensureIndex("{loc:'2d'}");
 

--- a/src/test/java/org/jongo/FindAndModifyTest.java
+++ b/src/test/java/org/jongo/FindAndModifyTest.java
@@ -138,7 +138,7 @@ public class FindAndModifyTest extends JongoTestBase {
             collection.findAndModify("{error: 'NotaDate'}").with("{$set: {error: 'StillNotaDate'}}").as(ErrorObject.class);
             fail();
         } catch (MarshallingException e) {
-            assertThat(e.getMessage()).contains(" \"error\" : \"NotaDate\"");
+            assertThat(e.getMessage()).contains("\"error\": \"NotaDate\"");
         }
     }
 

--- a/src/test/java/org/jongo/FindOneTest.java
+++ b/src/test/java/org/jongo/FindOneTest.java
@@ -120,7 +120,7 @@ public class FindOneTest extends JongoTestBase {
             collection.findOne().as(ErrorObject.class);
             fail();
         } catch (MarshallingException e) {
-            assertThat(e.getMessage()).contains(" \"error\" : \"NotaDate\"");
+            assertThat(e.getMessage()).contains(" \"error\": \"NotaDate\"");
         }
     }
 

--- a/src/test/java/org/jongo/FindTest.java
+++ b/src/test/java/org/jongo/FindTest.java
@@ -87,7 +87,7 @@ public class FindTest extends JongoTestBase {
             results.next();
             fail();
         } catch (MarshallingException e) {
-            assertThat(e.getMessage()).contains(" \"error\" : \"NotaDate\"");
+            assertThat(e.getMessage()).contains(" \"error\": \"NotaDate\"");
         }
     }
 

--- a/src/test/java/org/jongo/FindWithModifierTest.java
+++ b/src/test/java/org/jongo/FindWithModifierTest.java
@@ -69,8 +69,7 @@ public class FindWithModifierTest extends JongoTestBase {
         Iterator<Friend> friends = collection.find()
                 .with(new QueryModifier() {
                     public void modify(DBCursor cursor) {
-                        //TODO handle this properly (wether it is still relevant or not)
-                        //cursor.addSpecial("$maxScan", 1);
+                        cursor.limit(1);
                     }
                 })
                 .as(Friend.class);

--- a/src/test/java/org/jongo/FindWithModifierTest.java
+++ b/src/test/java/org/jongo/FindWithModifierTest.java
@@ -69,7 +69,8 @@ public class FindWithModifierTest extends JongoTestBase {
         Iterator<Friend> friends = collection.find()
                 .with(new QueryModifier() {
                     public void modify(DBCursor cursor) {
-                        cursor.addSpecial("$maxScan", 1);
+                        //TODO handle this properly (wether it is still relevant or not)
+                        //cursor.addSpecial("$maxScan", 1);
                     }
                 })
                 .as(Friend.class);

--- a/src/test/java/org/jongo/InsertTest.java
+++ b/src/test/java/org/jongo/InsertTest.java
@@ -100,7 +100,7 @@ public class InsertTest extends JongoTestBase {
 
         ObjectId id = ObjectId.get();
 
-        collection.withWriteConcern(WriteConcern.SAFE).insert(new Friend(id, "John"));
+        collection.withWriteConcern(WriteConcern.MAJORITY).insert(new Friend(id, "John"));
 
         assertThat(collection.count("{name : 'John'}")).isEqualTo(1);
 
@@ -111,7 +111,7 @@ public class InsertTest extends JongoTestBase {
     @Test
     public void canInsertAPojoWithACustomId() throws Exception {
 
-        collection.withWriteConcern(WriteConcern.SAFE).insert(new ExternalFriend("122", "value"));
+        collection.withWriteConcern(WriteConcern.MAJORITY).insert(new ExternalFriend("122", "value"));
 
         ExternalFriend result = collection.findOne("{name:'value'}").as(ExternalFriend.class);
         assertThat(result.getId()).isEqualTo("122");
@@ -122,10 +122,10 @@ public class InsertTest extends JongoTestBase {
 
         ObjectId id = ObjectId.get();
 
-        collection.withWriteConcern(WriteConcern.SAFE).insert(new Friend(id, "John"));
+        collection.withWriteConcern(WriteConcern.MAJORITY).insert(new Friend(id, "John"));
 
         try {
-            collection.withWriteConcern(WriteConcern.SAFE).insert(new Friend(id, "John"));
+            collection.withWriteConcern(WriteConcern.MAJORITY).insert(new Friend(id, "John"));
             Assert.fail();
         } catch (DuplicateKeyException e) {
         }
@@ -134,10 +134,10 @@ public class InsertTest extends JongoTestBase {
     @Test
     public void canOnlyInsertOnceAPojoWithACustomId() throws Exception {
 
-        collection.withWriteConcern(WriteConcern.SAFE).insert(new ExternalFriend("122", "value"));
+        collection.withWriteConcern(WriteConcern.MAJORITY).insert(new ExternalFriend("122", "value"));
 
         try {
-            collection.withWriteConcern(WriteConcern.SAFE).insert(new ExternalFriend("122", "other value"));
+            collection.withWriteConcern(WriteConcern.MAJORITY).insert(new ExternalFriend("122", "other value"));
             Assert.fail();
         } catch (DuplicateKeyException e) {
         }

--- a/src/test/java/org/jongo/MongoCollectionTest.java
+++ b/src/test/java/org/jongo/MongoCollectionTest.java
@@ -34,7 +34,7 @@ public class MongoCollectionTest extends JongoTestBase {
 
     @Before
     public void setUp() throws Exception {
-        collection = createEmptyCollection("friends").withWriteConcern(WriteConcern.SAFE);
+        collection = createEmptyCollection("friends").withWriteConcern(WriteConcern.MAJORITY);
     }
 
     @After

--- a/src/test/java/org/jongo/SaveTest.java
+++ b/src/test/java/org/jongo/SaveTest.java
@@ -24,7 +24,6 @@ import org.jongo.util.ErrorObject;
 import org.jongo.util.JongoTestBase;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Date;
@@ -161,7 +160,7 @@ public class SaveTest extends JongoTestBase {
     public void canUpdateAPojoWithACustomId() throws Exception {
 
         ExternalFriend externalFriend = new ExternalFriend("122", "John");
-        MongoCollection safeCollection = collection.withWriteConcern(WriteConcern.SAFE);
+        MongoCollection safeCollection = collection.withWriteConcern(WriteConcern.MAJORITY);
 
         safeCollection.save(externalFriend);
         externalFriend.setName("Robert");

--- a/src/test/java/org/jongo/UpdateTest.java
+++ b/src/test/java/org/jongo/UpdateTest.java
@@ -125,7 +125,7 @@ public class UpdateTest extends JongoTestBase {
 
         collection.update("{name:'John'}").with(preexistingDocument);
 
-        Friend johnny = collection.findOne("{name:'Johnny'}}").as(Friend.class);
+        Friend johnny = collection.findOne("{name:'Johnny'}").as(Friend.class);
         assertThat(johnny).isNotNull();
         assertThat(johnny.getName()).isEqualTo("Johnny");
         assertThat(johnny.getAddress()).isEqualTo("123 Wall Street");
@@ -139,7 +139,7 @@ public class UpdateTest extends JongoTestBase {
 
         collection.update("{name:'John'}").with(newDocument);
 
-        Friend johnny = collection.findOne("{name:'Johnny'}}").as(Friend.class);
+        Friend johnny = collection.findOne("{name:'Johnny'}").as(Friend.class);
         assertThat(johnny).isNotNull();
         assertThat(johnny.getName()).isEqualTo("Johnny");
         assertThat(johnny.getAddress()).isEqualTo("123 Wall Street");

--- a/src/test/java/org/jongo/UpdateTest.java
+++ b/src/test/java/org/jongo/UpdateTest.java
@@ -77,7 +77,7 @@ public class UpdateTest extends JongoTestBase {
         collection.save(new Friend("John"));
 
         /* when */
-        collection.withWriteConcern(WriteConcern.SAFE).update("{name:'John'}").multi().with("{$unset:{name:1}}");
+        collection.withWriteConcern(WriteConcern.MAJORITY).update("{name:'John'}").multi().with("{$unset:{name:1}}");
 
         /* then */
         Iterable<Friend> friends = collection.find("{name:{$exists:true}}").as(Friend.class);

--- a/src/test/java/org/jongo/WriteConcernTest.java
+++ b/src/test/java/org/jongo/WriteConcernTest.java
@@ -60,25 +60,25 @@ public class WriteConcernTest {
     @Test
     public void canInsertWithCustomWriteConcernOnCollection() throws Exception {
 
-        collection.withWriteConcern(WriteConcern.SAFE).insert("{name : 'Abby'}");
+        collection.withWriteConcern(WriteConcern.MAJORITY).insert("{name : 'Abby'}");
 
-        verify(mockedDBCollection).insert(any(DBObject.class), eq(WriteConcern.SAFE));
+        verify(mockedDBCollection).insert(any(DBObject.class), eq(WriteConcern.MAJORITY));
     }
 
     @Test
     public void canUpdateWithCustomWriteConcernOnCollection() throws Exception {
 
-        collection.withWriteConcern(WriteConcern.SAFE).update("{}").upsert().with("{$set:{name:'John'}}");
+        collection.withWriteConcern(WriteConcern.MAJORITY).update("{}").upsert().with("{$set:{name:'John'}}");
 
-        verify(mockedDBCollection).update(any(DBObject.class), any(DBObject.class), eq(true), eq(false), eq(WriteConcern.SAFE));
+        verify(mockedDBCollection).update(any(DBObject.class), any(DBObject.class), eq(true), eq(false), eq(WriteConcern.MAJORITY));
     }
 
     @Test
     public void canRemoveWithCustomWriteConcernOnCollection() throws Exception {
 
-        collection.withWriteConcern(WriteConcern.SAFE).remove();
+        collection.withWriteConcern(WriteConcern.MAJORITY).remove();
 
-        verify(mockedDBCollection).remove(any(DBObject.class), eq(WriteConcern.SAFE));
+        verify(mockedDBCollection).remove(any(DBObject.class), eq(WriteConcern.MAJORITY));
     }
 
 }

--- a/src/test/java/org/jongo/bench/BenchUtil.java
+++ b/src/test/java/org/jongo/bench/BenchUtil.java
@@ -49,12 +49,12 @@ class BenchUtil {
     }
 
     public static DBCollection getCollectionFromDriver() throws UnknownHostException {
-        Mongo nativeMongo = new MongoClient();
+        MongoClient nativeMongo = new MongoClient();
         return nativeMongo.getDB("jongo").getCollection("benchmark");
     }
 
     public static MongoCollection getCollectionFromJongo(Mapper mapper) throws UnknownHostException {
-        Mongo mongo = new MongoClient();
+        MongoClient mongo = new MongoClient();
         DB db = mongo.getDB("jongo");
         Jongo jongo = new Jongo(db, mapper);
         return jongo.getCollection("benchmark");
@@ -64,7 +64,7 @@ class BenchUtil {
         MongoCollection collection = getCollectionFromJongo(jacksonMapper().build());
         collection.drop();
         for (int i = 0; i < nbDocuments; i++) {
-            collection.withWriteConcern(WriteConcern.SAFE).save(createFriend(i));
+            collection.withWriteConcern(WriteConcern.MAJORITY).save(createFriend(i));
         }
         long count = collection.count();
         if (count < nbDocuments) {

--- a/src/test/java/org/jongo/bench/SaveBench.java
+++ b/src/test/java/org/jongo/bench/SaveBench.java
@@ -36,7 +36,7 @@ public class SaveBench extends SimpleBenchmark {
 
     protected void setUp() throws Exception {
 
-        bsonCollection = getCollectionFromJongo(jacksonMapper().build()).withWriteConcern(WriteConcern.SAFE);
+        bsonCollection = getCollectionFromJongo(jacksonMapper().build()).withWriteConcern(WriteConcern.MAJORITY);
         dbCollection = getCollectionFromDriver();
 
         bsonCollection.drop();

--- a/src/test/java/org/jongo/marshall/DocumentMarshallingTest.java
+++ b/src/test/java/org/jongo/marshall/DocumentMarshallingTest.java
@@ -18,6 +18,8 @@ package org.jongo.marshall;
 
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
+import org.bson.BsonBinary;
+import org.bson.UuidRepresentation;
 import org.bson.types.*;
 import org.jongo.MongoCollection;
 import org.jongo.model.Friend;
@@ -166,10 +168,11 @@ public class DocumentMarshallingTest extends JongoTestBase {
 
         BSONPrimitiveType type = new BSONPrimitiveType();
         type.uuid = UUID.fromString("cf0eddfa-2670-4929-a581-eb263d839cab");
+        String uuidBase64 = Base64.getEncoder().encodeToString(new BsonBinary(type.uuid, UuidRepresentation.JAVA_LEGACY).getData());
 
         collection.save(type);
 
-        assertHasBeenPersistedAs("{'uuid' : { '$uuid' : 'cf0eddfa-2670-4929-a581-eb263d839cab'}}");
+        assertHasBeenPersistedAs("{'uuid' : {'$binary': {'base64': '" + uuidBase64 + "', 'subType': '03'}}}");
         BSONPrimitiveType result = collection.findOne("{}").as(BSONPrimitiveType.class);
         assertThat(result.uuid).isEqualTo(type.uuid);
     }

--- a/src/test/java/org/jongo/marshall/jackson/JacksonMapperTest.java
+++ b/src/test/java/org/jongo/marshall/jackson/JacksonMapperTest.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.introspect.VisibilityChecker;
 import com.fasterxml.jackson.databind.module.SimpleDeserializers;

--- a/src/test/java/org/jongo/marshall/jackson/JacksonMapperTest.java
+++ b/src/test/java/org/jongo/marshall/jackson/JacksonMapperTest.java
@@ -67,7 +67,7 @@ public class JacksonMapperTest {
 
         BsonDocument document = mapper.getMarshaller().marshall(robert);
 
-        assertThat(document.toString()).contains("{ \"name\" : \"Doe\"}");
+        assertThat(document.toString()).contains("{\"name\": \"Doe\"}");
     }
 
     @Test
@@ -81,7 +81,7 @@ public class JacksonMapperTest {
 
         BsonDocument document = mapper.getMarshaller().marshall(robert);
 
-        assertThat(document.toString()).isEqualTo("{ \"firstName\" : \"Robert\"}");
+        assertThat(document.toString()).isEqualTo("{\"firstName\": \"Robert\"}");
     }
 
     @SuppressWarnings("serial")
@@ -94,7 +94,7 @@ public class JacksonMapperTest {
 
         BsonDocument document = mapper.getMarshaller().marshall(external);
 
-        assertThat(document.toString()).isEqualTo("{ \"name\" : \"Robert\" , \"_id\" : { \"$oid\" : \"" + id + "\"}}");
+        assertThat(document.toString()).isEqualTo("{\"_id\": {\"$oid\": \"563667f82249254c42530fe3\"}, \"name\": \"Robert\"}");
     }
 
     @Test
@@ -125,7 +125,7 @@ public class JacksonMapperTest {
 
         BsonDocument document = mapper.getMarshaller().marshall(friend);
 
-        assertThat(document.toString()).contains("\"_id\" : { \"$oid\" : \"504482e5e4b0d1b2c47fff66\"}");
+        assertThat(document.toString()).contains("\"_id\": {\"$oid\": \"504482e5e4b0d1b2c47fff66\"}");
     }
 
     @Test

--- a/src/test/java/org/jongo/marshall/jackson/JacksonMixinTest.java
+++ b/src/test/java/org/jongo/marshall/jackson/JacksonMixinTest.java
@@ -44,7 +44,7 @@ public class JacksonMixinTest {
 
         BsonDocument document = mapper.getMarshaller().marshall(external);
 
-        assertThat(document.toString()).isEqualTo("{ \"_id\" : { \"$oid\" : \"" + id + "\"} , \"name\" : \"Robert\"}");
+        assertThat(document.toString()).isEqualTo("{\"_id\": {\"$oid\": \"" + id + "\"}, \"name\": \"Robert\"}");
     }
 
     /**

--- a/src/test/java/org/jongo/query/BsonQueryFactoryTest.java
+++ b/src/test/java/org/jongo/query/BsonQueryFactoryTest.java
@@ -123,6 +123,16 @@ public class BsonQueryFactoryTest {
     }
 
     @Test
+    public void shouldBindParameterWithCustomLongToken() throws Exception {
+
+        QueryFactory factoryWithToken = new BsonQueryFactory(new JacksonEngine(Mapping.defaultMapping()), "#!!");
+
+        Query query = factoryWithToken.createQuery("{id:#!!}", 123);
+
+        assertThat(query.toDBObject()).isEqualTo(new BasicDBObject("id", 123));
+    }
+
+    @Test
     public void shouldBindHashSign() throws Exception {
 
         Query query = factory.createQuery("{id:#}", "string with # sign");

--- a/src/test/java/org/jongo/query/BsonQueryFactoryTest.java
+++ b/src/test/java/org/jongo/query/BsonQueryFactoryTest.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
 import com.mongodb.QueryBuilder;
+import org.bson.types.ObjectId;
 import org.jongo.marshall.jackson.JacksonEngine;
 import org.jongo.marshall.jackson.configuration.Mapping;
 import org.jongo.model.Coordinate;
@@ -100,6 +101,15 @@ public class BsonQueryFactoryTest {
         Query query = factory.createQuery("{id:#}", null);
 
         assertThat(query.toDBObject()).isEqualTo(new BasicDBObject("id", null));
+    }
+
+    @Test
+    public void shouldBindObjectIdParameter() throws Exception {
+
+        ObjectId objectId = new ObjectId();
+        Query query = factory.createQuery("{_id:{$oid:#}}", objectId.toHexString());
+
+        assertThat(query.toDBObject()).isEqualTo(new BasicDBObject("_id", objectId));
     }
 
     @Test

--- a/src/test/java/org/jongo/query/BsonQueryFactoryTest.java
+++ b/src/test/java/org/jongo/query/BsonQueryFactoryTest.java
@@ -44,6 +44,14 @@ public class BsonQueryFactoryTest {
         factory = new BsonQueryFactory(new JacksonEngine(Mapping.defaultMapping()));
     }
 
+    @Test
+    public void shouldCreateSimpleQuery() throws Exception {
+
+        Query query = factory.createQuery("{id:'\"[12,.:[]{}3]'}");
+
+        assertThat(query.toDBObject()).isEqualTo(QueryBuilder.start("id").is("\"[12,.:[]{}3]").get());
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void shouldFailWithInvalidParameter() throws Exception {
 

--- a/src/test/java/org/jongo/spike/MongoDumpTest.java
+++ b/src/test/java/org/jongo/spike/MongoDumpTest.java
@@ -59,7 +59,7 @@ public class MongoDumpTest extends JongoTestBase {
         try {
             while (iterator.hasNext()) {
                 BSONObject bsonObject = iterator.next();
-                collection.withWriteConcern(WriteConcern.SAFE).save(bsonObject);
+                collection.withWriteConcern(WriteConcern.MAJORITY).save(bsonObject);
             }
         } finally {
             iterator.close();

--- a/src/test/java/org/jongo/spike/QuestionsSpikeTest.java
+++ b/src/test/java/org/jongo/spike/QuestionsSpikeTest.java
@@ -17,12 +17,7 @@
 package org.jongo.spike;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.TreeNode;
-import com.fasterxml.jackson.databind.*;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mongodb.DBObject;
 import com.mongodb.QueryBuilder;
 import org.bson.types.Decimal128;
@@ -37,15 +32,12 @@ import org.jongo.marshall.Unmarshaller;
 import org.jongo.marshall.jackson.JacksonEngine;
 import org.jongo.marshall.jackson.configuration.MapperModifier;
 import org.jongo.marshall.jackson.configuration.Mapping;
-import org.jongo.marshall.jackson.oid.ObjectIdDeserializer;
 import org.jongo.model.Friend;
 import org.jongo.util.JongoTestBase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.IOException;
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;

--- a/src/test/java/org/jongo/spike/projection/JacksonProjection.java
+++ b/src/test/java/org/jongo/spike/projection/JacksonProjection.java
@@ -23,8 +23,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
 import com.mongodb.MongoClient;
+import org.bson.BsonDocument;
 import org.bson.BsonDocumentWrapper;
-import org.bson.conversions.Bson;
 import org.jongo.query.Query;
 
 import java.util.Iterator;
@@ -83,7 +83,7 @@ public class JacksonProjection implements Projection {
             return dbo;
         }
 
-        public Bson toBson() {
+        public BsonDocument toBsonDocument() {
             return BsonDocumentWrapper.asBsonDocument(dbo, MongoClient.getDefaultCodecRegistry());
         }
     }

--- a/src/test/java/org/jongo/use_native/BsonNativeTest.java
+++ b/src/test/java/org/jongo/use_native/BsonNativeTest.java
@@ -23,6 +23,7 @@ import com.mongodb.WriteConcern;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import org.bson.BsonDocument;
+import org.bson.BsonString;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.junit.After;
@@ -33,11 +34,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class BsonNativeTest extends NativeTestBase {
 
-    private MongoCollection<Bson> collection;
+    private MongoCollection<BsonDocument> collection;
 
     @Before
     public void setUp() throws Exception {
-        collection = jongo.getCollection("friends", Bson.class).withWriteConcern(WriteConcern.ACKNOWLEDGED);
+        collection = jongo.getCollection("friends", BsonDocument.class).withWriteConcern(WriteConcern.ACKNOWLEDGED);
     }
 
     @After
@@ -66,12 +67,12 @@ public class BsonNativeTest extends NativeTestBase {
 
         collection.insertOne(q("{name : 'Abby'}"));
 
-        FindIterable<Bson> results = collection.find(q("{name:'Abby'}")).projection(q("{name:#}", 1));
+        FindIterable<BsonDocument> results = collection.find(q("{name:'Abby'}")).projection(q("{name:#}", 1));
 
         assertThat(results).isNotEmpty();
-        results.map(new Function<Bson, String>() {
+        results.map(new Function<BsonDocument, String>() {
 
-            public String apply(Bson bson) {
+            public String apply(BsonDocument bson) {
                 BsonDocument document = bson.toBsonDocument(DBObject.class, MongoClient.getDefaultCodecRegistry());
                 assertThat(document.containsKey("address")).isFalse();
                 assertThat(document.containsKey("name")).isTrue();
@@ -83,7 +84,7 @@ public class BsonNativeTest extends NativeTestBase {
     @Test
     public void canQueryWithNativeDocument() throws Exception {
 
-        Document document = new Document("name", "Abby").append("address", "123 Wall Street");
+        BsonDocument document = new BsonDocument("name", new BsonString("Abby")).append("address", new BsonString("123 Wall Street"));
 
         collection.insertOne(document);
 

--- a/src/test/java/org/jongo/use_native/InsertNativeTest.java
+++ b/src/test/java/org/jongo/use_native/InsertNativeTest.java
@@ -162,7 +162,7 @@ public class InsertNativeTest extends NativeTestBase {
 
         collection.insertMany(newArrayList(new Friend("John"), new Friend("Robert")));
 
-        assertThat(collection.count()).isEqualTo(2);
+        assertThat(collection.countDocuments()).isEqualTo(2);
         Iterable<Friend> friends = collection.find();
         assertThat(friends).extracting("name").containsExactly("John", "Robert");
     }

--- a/src/test/java/org/jongo/use_native/NativeTestBase.java
+++ b/src/test/java/org/jongo/use_native/NativeTestBase.java
@@ -17,6 +17,7 @@
 package org.jongo.use_native;
 
 import com.mongodb.client.MongoDatabase;
+import org.bson.BsonDocument;
 import org.bson.conversions.Bson;
 import org.jongo.Jongo;
 import org.jongo.JongoNative;
@@ -46,7 +47,7 @@ public abstract class NativeTestBase {
         MONGO_RESOURCE = new MongoResource();
     }
 
-    protected Bson q(String query, Object... parameters) {
+    protected BsonDocument q(String query, Object... parameters) {
         return jongo.query(query, parameters);
     }
 


### PR DESCRIPTION
Driver breaking changes :
* JSON class was removed, use BasicDBObject instead
* ObjectId.createFromLegacyFormat method was removed use new ObjectId() instead
* no longer java 1.5 compatible hence the upgrade to java 8
* $maxScan operator no longer supported
* BsonCodec does not implement the decode method
* UUID are no longer serialized using $uuid operator
* null countOption no longer supported

Also upgrade
* de.flapdoodle.embed.mongo 2.2.0 -> 3.0.0
* de.undercouch.bson4jackson 2.9.2 -> 2.12.0